### PR TITLE
Add update checker and shell integration

### DIFF
--- a/src/components/app-router.tsx
+++ b/src/components/app-router.tsx
@@ -12,7 +12,9 @@ import {
 } from "../panels/index.js"
 import type { WorktreeService } from "../services/index.js"
 import type { ShellIntegrationStatus } from "../services/shell-integration-service.js"
+import type { UpdateCheckResult } from "../services/update-service.js"
 import type { AppMode } from "../types/index.js"
+import { UpdateBanner } from "./update-banner.js"
 import { WelcomeHeader } from "./welcome-header.js"
 
 interface AppRouterProps {
@@ -21,6 +23,7 @@ interface AppRouterProps {
   lastMenuIndex: number
   gitRoot?: string | undefined
   shellIntegrationStatus: ShellIntegrationStatus | null
+  updateStatus: UpdateCheckResult | null
   isFromWrapper: boolean
   onMenuSelect: (value: AppMode | "exit", selectedIndex?: number) => void
   onBackToMenu: () => void
@@ -34,6 +37,7 @@ export function AppRouter({
   lastMenuIndex,
   gitRoot,
   shellIntegrationStatus,
+  updateStatus,
   isFromWrapper,
   onMenuSelect,
   onBackToMenu,
@@ -45,6 +49,7 @@ export function AppRouter({
   return (
     <BorderContext.Provider value={{ setBorderColor }}>
       <Box flexDirection="column">
+        <UpdateBanner updateStatus={updateStatus} />
         <WelcomeHeader mode={mode} gitRoot={gitRoot} />
 
         {mode === "menu" && (

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -64,13 +64,13 @@ export function App({ initialMode = "menu", isFromWrapper = false, onExit }: App
         UpdateService.checkForUpdates(VERSION, configService)
           .then(setUpdateStatus)
           .catch(() => {
-            const cached = UpdateService.getCachedUpdateStatus(configService)
+            const cached = UpdateService.getCachedUpdateStatus(configService, VERSION)
             if (cached) {
               setUpdateStatus(cached)
             }
           })
       } else {
-        const cached = UpdateService.getCachedUpdateStatus(configService)
+        const cached = UpdateService.getCachedUpdateStatus(configService, VERSION)
         if (cached) {
           setUpdateStatus(cached)
         }

--- a/src/components/update-banner.tsx
+++ b/src/components/update-banner.tsx
@@ -1,0 +1,32 @@
+import { Box, Text } from "ink"
+import { COLORS } from "../constants/index.js"
+import type { UpdateCheckResult } from "../services/update-service.js"
+
+interface UpdateBannerProps {
+  updateStatus: UpdateCheckResult | null
+}
+
+export function UpdateBanner({ updateStatus }: UpdateBannerProps) {
+  if (!updateStatus || !updateStatus.hasUpdate || !updateStatus.latestVersion) {
+    return null
+  }
+
+  return (
+    <Box borderStyle="round" paddingX={1} paddingY={0} borderColor={COLORS.WARNING} marginBottom={1}>
+      <Box flexDirection="column">
+        <Text>
+          <Text color={COLORS.WARNING}>⚠ Update Available:</Text>
+          {" "}
+          <Text color={COLORS.MUTED}>v{updateStatus.currentVersion}</Text>
+          {" → "}
+          <Text bold color={COLORS.SUCCESS}>
+            v{updateStatus.latestVersion}
+          </Text>
+        </Text>
+        <Text color={COLORS.MUTED}>
+          Run: <Text bold color={COLORS.PRIMARY}>npm install -g branchlet</Text> to update
+        </Text>
+      </Box>
+    </Box>
+  )
+}

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -70,6 +70,14 @@ export const MESSAGES = {
   LOADING_GIT_INFO: "Loading git information...",
   LOADING_BRANCHES: "Loading branches...",
   LOADING_WORKTREES: "Loading worktrees...",
+
+  // Update checking
+  UPDATE_AVAILABLE: "Update available",
+  UPDATE_CHECK_MENU: "Check for Updates",
+  UPDATE_CHECKING: "Checking for updates...",
+  UPDATE_UP_TO_DATE: "You're running the latest version",
+  UPDATE_FAILED: "Failed to check for updates",
+  UPDATE_INSTALL_CMD: "npm install -g branchlet",
 } as const
 
 export const COLORS = {

--- a/src/schemas/config-schema.ts
+++ b/src/schemas/config-schema.ts
@@ -30,6 +30,18 @@ export const WorktreeConfigSchema = z
       .boolean()
       .default(false)
       .describe("Also delete the associated git branch when deleting a worktree"),
+    lastUpdateCheck: z
+      .number()
+      .optional()
+      .describe("Timestamp of last update check (milliseconds since epoch)"),
+    latestVersion: z
+      .string()
+      .optional()
+      .describe("Latest version available on npm"),
+    checkedVersion: z
+      .string()
+      .optional()
+      .describe("Version that was current when last checked"),
   })
   .describe("Configuration for Git worktree management tool")
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,5 @@
 export * from "./config-service.js"
 export * from "./file-service.js"
 export * from "./git-service.js"
+export * from "./update-service.js"
 export * from "./worktree-service.js"

--- a/src/services/update-service.ts
+++ b/src/services/update-service.ts
@@ -1,0 +1,108 @@
+import type { ConfigService } from "./config-service.js"
+import { isNewerVersion } from "../utils/version-compare.js"
+
+export interface UpdateCheckResult {
+  hasUpdate: boolean
+  currentVersion: string
+  latestVersion?: string
+  checkedAt: number
+  error?: string
+}
+
+// biome-ignore lint/complexity/noStaticOnlyClass: Service class pattern
+export class UpdateService {
+  private static readonly NPM_REGISTRY_URL = "https://registry.npmjs.org/branchlet/latest"
+  private static readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+  static shouldCheckForUpdates(configService: ConfigService): boolean {
+    const config = configService.getConfig()
+    const lastCheck = config.lastUpdateCheck || 0
+    const now = Date.now()
+    return now - lastCheck >= UpdateService.CACHE_TTL_MS
+  }
+
+  static async checkForUpdates(
+    currentVersion: string,
+    configService: ConfigService
+  ): Promise<UpdateCheckResult> {
+    const config = configService.getConfig()
+    const now = Date.now()
+
+    if (!UpdateService.shouldCheckForUpdates(configService)) {
+      return (
+        UpdateService.getCachedUpdateStatus(configService) || {
+          hasUpdate: false,
+          currentVersion,
+          checkedAt: config.lastUpdateCheck || now,
+        }
+      )
+    }
+
+    try {
+      const latestVersion = await UpdateService.fetchLatestVersion()
+      const hasUpdate = isNewerVersion(currentVersion, latestVersion)
+
+      const updatedConfig = configService.updateConfig({
+        lastUpdateCheck: now,
+        latestVersion: latestVersion,
+        checkedVersion: currentVersion,
+      })
+
+      configService.saveConfig(updatedConfig).catch(() => {})
+
+      return {
+        hasUpdate,
+        currentVersion,
+        latestVersion,
+        checkedAt: now,
+      }
+    } catch (error) {
+      return {
+        hasUpdate: false,
+        currentVersion,
+        checkedAt: now,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  static getCachedUpdateStatus(configService: ConfigService): UpdateCheckResult | null {
+    const config = configService.getConfig()
+
+    if (!config.lastUpdateCheck || !config.latestVersion || !config.checkedVersion) {
+      return null
+    }
+
+    const hasUpdate = isNewerVersion(config.checkedVersion, config.latestVersion)
+
+    return {
+      hasUpdate,
+      currentVersion: config.checkedVersion,
+      latestVersion: config.latestVersion,
+      checkedAt: config.lastUpdateCheck,
+    }
+  }
+
+  private static async fetchLatestVersion(): Promise<string> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+    try {
+      const response = await fetch(UpdateService.NPM_REGISTRY_URL, {
+        signal: controller.signal,
+        headers: {
+          Accept: "application/json",
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+
+      const data = (await response.json()) as { version: string }
+      return data.version
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+}

--- a/src/services/update-service.ts
+++ b/src/services/update-service.ts
@@ -30,7 +30,7 @@ export class UpdateService {
 
     if (!UpdateService.shouldCheckForUpdates(configService)) {
       return (
-        UpdateService.getCachedUpdateStatus(configService) || {
+        UpdateService.getCachedUpdateStatus(configService, currentVersion) || {
           hasUpdate: false,
           currentVersion,
           checkedAt: config.lastUpdateCheck || now,
@@ -66,18 +66,22 @@ export class UpdateService {
     }
   }
 
-  static getCachedUpdateStatus(configService: ConfigService): UpdateCheckResult | null {
+  static getCachedUpdateStatus(
+    configService: ConfigService,
+    currentVersion?: string
+  ): UpdateCheckResult | null {
     const config = configService.getConfig()
 
-    if (!config.lastUpdateCheck || !config.latestVersion || !config.checkedVersion) {
+    if (!config.lastUpdateCheck || !config.latestVersion) {
       return null
     }
 
-    const hasUpdate = isNewerVersion(config.checkedVersion, config.latestVersion)
+    const version = currentVersion || config.checkedVersion || config.latestVersion
+    const hasUpdate = isNewerVersion(version, config.latestVersion)
 
     return {
       hasUpdate,
-      currentVersion: config.checkedVersion,
+      currentVersion: version,
       latestVersion: config.latestVersion,
       checkedAt: config.lastUpdateCheck,
     }

--- a/src/utils/version-compare.ts
+++ b/src/utils/version-compare.ts
@@ -1,0 +1,70 @@
+interface SemanticVersion {
+  major: number
+  minor: number
+  patch: number
+  prerelease?: string | undefined
+}
+
+function parseVersion(version: string): SemanticVersion {
+  const cleaned = version.replace(/^v/, "")
+
+  const [versionPart, prerelease] = cleaned.split("-")
+
+  if (!versionPart) {
+    throw new Error(`Invalid version format: ${version}`)
+  }
+
+  const parts = versionPart.split(".")
+
+  if (parts.length < 3 || !parts[0] || !parts[1] || !parts[2]) {
+    throw new Error(`Invalid version format: ${version}`)
+  }
+
+  return {
+    major: Number.parseInt(parts[0], 10),
+    minor: Number.parseInt(parts[1], 10),
+    patch: Number.parseInt(parts[2], 10),
+    prerelease,
+  }
+}
+
+/**
+ * Compares two semantic version strings
+ * Returns true if version2 is newer than version1
+ *
+ * Examples:
+ *   isNewerVersion("0.2.0", "0.3.0") => true
+ *   isNewerVersion("0.2.0", "1.0.0") => true
+ *   isNewerVersion("0.2.0", "0.2.0") => false
+ *   isNewerVersion("0.3.0", "0.2.0") => false
+ */
+export function isNewerVersion(version1: string, version2: string): boolean {
+  try {
+    const v1 = parseVersion(version1)
+    const v2 = parseVersion(version2)
+
+    if (v2.major > v1.major) return true
+    if (v2.major < v1.major) return false
+
+    if (v2.minor > v1.minor) return true
+    if (v2.minor < v1.minor) return false
+
+    if (v2.patch > v1.patch) return true
+
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Validates if a string is a valid semantic version
+ */
+export function isValidVersion(version: string): boolean {
+  try {
+    parseVersion(version)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Automatic update checker that queries the npm registry every 24 hours and shows a banner when a new version is out
- Shell integration: setup panel, wrapper script generation (bash/zsh/fish), and quick-cd mode so users can cd into branches directly from their shell
- Shell completion command for tab-completing branch names
- Settings option to disable update checks
- Version bump to 0.2.0, dependency updates
