### PR TITLE
Default to current branch and add viewport scrolling in SelectPrompt

### DIFF
--- a/src/panels/create/index.tsx
+++ b/src/panels/create/index.tsx
@@ -233,16 +233,20 @@ export function CreateWorktree({ worktreeService, onComplete, onCancel }: Create
         />
       )
 
-    case "source-branch":
+    case "source-branch": {
+      const branchOptions = getBranchOptions()
+      const defaultIndex = branchOptions.findIndex((opt) => opt.isDefault)
       return (
         <SelectPrompt
           label={MESSAGES.CREATE_SOURCE_BRANCH_PROMPT}
-          options={getBranchOptions()}
+          options={branchOptions}
+          defaultIndex={defaultIndex >= 0 ? defaultIndex : 0}
           onSelect={handleSourceBranchSelect}
           onCancel={onCancel}
           searchable={true}
         />
       )
+    }
 
     case "new-branch":
       return (


### PR DESCRIPTION
## Summary

Fixes source branch selection to default to the current branch and adds viewport scrolling for repos with many branches.

Based on #21 by @ckrowbar. Closes #19.

## Changes

- Source branch selector now starts on the current branch instead of the first branch in the list
- SelectPrompt shows 10 options at a time with viewport windowing that follows the cursor
- Displays "N more above" / "N more below" indicators when the list is scrollable
- Viewport works correctly with search filtering