### PR TITLE
Force fresh fetch on manual update check

### DIFF
--- a/src/panels/settings/index.tsx
+++ b/src/panels/settings/index.tsx
@@ -81,7 +81,7 @@ export function SettingsMenu({ worktreeService, onBack }: SettingsMenuProps) {
       setCheckingUpdates(true)
       const configService = worktreeService.getConfigService()
 
-      UpdateService.checkForUpdates(VERSION, configService)
+      UpdateService.checkForUpdates(VERSION, configService, true)
         .then((result) => {
           setManualUpdateResult(result)
           setCheckingUpdates(false)

--- a/src/panels/settings/index.tsx
+++ b/src/panels/settings/index.tsx
@@ -7,7 +7,7 @@ import { COLORS, MESSAGES } from "../../constants/index.js"
 import type { WorktreeConfig } from "../../schemas/config-schema.js"
 import type { WorktreeService } from "../../services/index.js"
 import type { UpdateCheckResult } from "../../services/update-service.js"
-import { UpdateService } from "../../services/update-service.js"
+import { checkForUpdates } from "../../services/update-service.js"
 import type { SelectOption } from "../../types/index.js"
 
 const VERSION = packageJson.version
@@ -81,7 +81,7 @@ export function SettingsMenu({ worktreeService, onBack }: SettingsMenuProps) {
       setCheckingUpdates(true)
       const configService = worktreeService.getConfigService()
 
-      UpdateService.checkForUpdates(VERSION, configService, true)
+      checkForUpdates(VERSION, configService, true)
         .then((result) => {
           setManualUpdateResult(result)
           setCheckingUpdates(false)

--- a/src/panels/setup/index.tsx
+++ b/src/panels/setup/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import { ConfirmDialog, SelectPrompt, StatusIndicator } from "../../components/common/index.js"
 import { COLORS } from "../../constants/index.js"
 import {
-  ShellIntegrationService,
+  installShellIntegration,
   type ShellIntegrationStatus,
 } from "../../services/shell-integration-service.js"
 import type { SelectOption } from "../../types/index.js"
@@ -54,7 +54,7 @@ export function SetupShellIntegration({
     setError(undefined)
 
     try {
-      await ShellIntegrationService.install(selectedShell, "branchlet")
+      await installShellIntegration(selectedShell, "branchlet")
       setStep("success")
 
       setTimeout(() => {

--- a/src/services/shell-integration-service.ts
+++ b/src/services/shell-integration-service.ts
@@ -10,203 +10,198 @@ export interface ShellIntegrationStatus {
   reason?: string
 }
 
-// biome-ignore lint/complexity/noStaticOnlyClass: Service class pattern
-export class ShellIntegrationService {
-  private static readonly WRAPPER_SIGNATURE = "# Branchlet setup: added on"
-  private static readonly SETUP_END_MARKER = "# End Branchlet setup"
+const WRAPPER_SIGNATURE = "# Branchlet setup: added on"
+const SETUP_END_MARKER = "# End Branchlet setup"
 
-  /**
-   * Detects if shell integration is installed
-   */
-  static async detect(): Promise<ShellIntegrationStatus> {
-    const shell = ShellIntegrationService.detectShell()
-    const configPath = ShellIntegrationService.getConfigPath(shell)
+/**
+ * Detects if shell integration is installed
+ */
+export async function detectShellIntegration(): Promise<ShellIntegrationStatus> {
+  const shell = detectShell()
+  const configPath = getConfigPath(shell)
 
-    if (!configPath) {
-      return {
-        isInstalled: false,
-        shell,
-        configPath: null,
-        reason: "Could not determine shell config file",
-      }
+  if (!configPath) {
+    return {
+      isInstalled: false,
+      shell,
+      configPath: null,
+      reason: "Could not determine shell config file",
     }
+  }
 
-    if (!existsSync(configPath)) {
-      return {
-        isInstalled: false,
-        shell,
-        configPath,
-        reason: "Config file does not exist",
-      }
+  if (!existsSync(configPath)) {
+    return {
+      isInstalled: false,
+      shell,
+      configPath,
+      reason: "Config file does not exist",
     }
+  }
 
-    try {
-      const content = await readFile(configPath, "utf-8")
-      const isInstalled = content.includes(ShellIntegrationService.WRAPPER_SIGNATURE)
+  try {
+    const content = await readFile(configPath, "utf-8")
+    const isInstalled = content.includes(WRAPPER_SIGNATURE)
 
-      if (isInstalled) {
-        return {
-          isInstalled,
-          shell,
-          configPath,
-        }
-      }
-
+    if (isInstalled) {
       return {
         isInstalled,
         shell,
         configPath,
-        reason: "Shell integration not found in config",
       }
-    } catch (error) {
-      return {
-        isInstalled: false,
-        shell,
-        configPath,
-        reason: `Failed to read config: ${error}`,
-      }
+    }
+
+    return {
+      isInstalled,
+      shell,
+      configPath,
+      reason: "Shell integration not found in config",
+    }
+  } catch (error) {
+    return {
+      isInstalled: false,
+      shell,
+      configPath,
+      reason: `Failed to read config: ${error}`,
     }
   }
+}
 
-  /**
-   * Installs shell integration to the user's shell config
-   */
-  static async install(shell: "zsh" | "bash", commandName = "branchlet"): Promise<void> {
-    const configPath = ShellIntegrationService.getConfigPath(shell)
-    if (!configPath) {
-      throw new Error("Could not determine shell config path")
-    }
-
-    const setupBlock = ShellIntegrationService.generateSetupBlock(shell, commandName)
-
-    // Check if already installed
-    if (existsSync(configPath)) {
-      const content = await readFile(configPath, "utf-8")
-      if (content.includes(ShellIntegrationService.WRAPPER_SIGNATURE)) {
-        const lines = content.split("\n")
-        const startIndex = lines.findIndex((line) =>
-          line.includes(ShellIntegrationService.WRAPPER_SIGNATURE)
-        )
-
-        if (startIndex !== -1) {
-          const endIndex = ShellIntegrationService.findSetupEndIndex(lines, startIndex)
-
-          // Remove old integration
-          lines.splice(startIndex, endIndex - startIndex + 1)
-          await writeFile(configPath, lines.join("\n"), "utf-8")
-        }
-      }
-    }
-
-    // Append new integration
-    const contentToAppend = `\n${setupBlock}\n`
-
-    if (existsSync(configPath)) {
-      await writeFile(configPath, contentToAppend, { flag: "a", encoding: "utf-8" })
-    } else {
-      await writeFile(configPath, contentToAppend, "utf-8")
-    }
+/**
+ * Installs shell integration to the user's shell config
+ */
+export async function installShellIntegration(
+  shell: "zsh" | "bash",
+  commandName = "branchlet"
+): Promise<void> {
+  const configPath = getConfigPath(shell)
+  if (!configPath) {
+    throw new Error("Could not determine shell config path")
   }
 
-  /**
-   * Removes shell integration from config file
-   */
-  static async remove(shell: "zsh" | "bash"): Promise<void> {
-    const configPath = ShellIntegrationService.getConfigPath(shell)
-    if (!configPath || !existsSync(configPath)) {
-      return
-    }
+  const setupBlock = generateSetupBlock(shell, commandName)
 
+  // Check if already installed
+  if (existsSync(configPath)) {
     const content = await readFile(configPath, "utf-8")
-    if (!content.includes(ShellIntegrationService.WRAPPER_SIGNATURE)) {
-      return
-    }
+    if (content.includes(WRAPPER_SIGNATURE)) {
+      const lines = content.split("\n")
+      const startIndex = lines.findIndex((line) => line.includes(WRAPPER_SIGNATURE))
 
-    const lines = content.split("\n")
-    const startIndex = lines.findIndex((line) =>
-      line.includes(ShellIntegrationService.WRAPPER_SIGNATURE)
-    )
+      if (startIndex !== -1) {
+        const endIndex = findSetupEndIndex(lines, startIndex)
 
-    if (startIndex !== -1) {
-      const endIndex = ShellIntegrationService.findSetupEndIndex(lines, startIndex)
-
-      // Remove the integration block including surrounding blank lines
-      const removeStart =
-        startIndex > 0 && lines[startIndex - 1]?.trim() === "" ? startIndex - 1 : startIndex
-      const removeEnd =
-        endIndex + 1 < lines.length && lines[endIndex + 1]?.trim() === "" ? endIndex + 1 : endIndex
-
-      lines.splice(removeStart, removeEnd - removeStart + 1)
-      await writeFile(configPath, lines.join("\n"), "utf-8")
-    }
-  }
-
-  /**
-   * Detects the user's shell from environment
-   */
-  private static detectShell(): "zsh" | "bash" | "unknown" {
-    const shell = process.env.SHELL?.toLowerCase() || ""
-
-    if (shell.includes("zsh")) {
-      return "zsh"
-    }
-    if (shell.includes("bash")) {
-      return "bash"
-    }
-
-    return "unknown"
-  }
-
-  /**
-   * Gets the config file path for the given shell
-   */
-  private static getConfigPath(shell: "zsh" | "bash" | "unknown"): string | null {
-    const home = homedir()
-
-    switch (shell) {
-      case "zsh":
-        return join(home, ".zshrc")
-      case "bash":
-        return join(home, ".bashrc")
-      default:
-        return null
-    }
-  }
-
-  /**
-   * Finds the end index of the setup block, using end marker with fallback
-   */
-  private static findSetupEndIndex(lines: string[], startIndex: number): number {
-    // Look for end marker first
-    for (let i = startIndex + 1; i < lines.length; i++) {
-      if (lines[i]?.includes(ShellIntegrationService.SETUP_END_MARKER)) {
-        return i
+        // Remove old integration
+        lines.splice(startIndex, endIndex - startIndex + 1)
+        await writeFile(configPath, lines.join("\n"), "utf-8")
       }
     }
-
-    // Fallback for old installations without end marker: find last closing brace
-    let endIndex = startIndex
-    for (let i = startIndex + 1; i < lines.length; i++) {
-      if (lines[i]?.trim() === "}") {
-        endIndex = i
-      }
-      // Stop searching after a reasonable distance
-      if (i - startIndex > 50) break
-    }
-    return endIndex
   }
 
-  /**
-   * Generates the full setup block including completions and wrapper function
-   */
-  private static generateSetupBlock(shell: "zsh" | "bash", commandName: string): string {
-    const today = new Date().toISOString().split("T")[0]
-    const completions =
-      shell === "zsh"
-        ? ShellIntegrationService.generateZshCompletions()
-        : ShellIntegrationService.generateBashCompletions()
+  // Append new integration
+  const contentToAppend = `\n${setupBlock}\n`
 
-    return `${ShellIntegrationService.WRAPPER_SIGNATURE} ${today}
+  if (existsSync(configPath)) {
+    await writeFile(configPath, contentToAppend, { flag: "a", encoding: "utf-8" })
+  } else {
+    await writeFile(configPath, contentToAppend, "utf-8")
+  }
+}
+
+/**
+ * Removes shell integration from config file
+ */
+export async function removeShellIntegration(shell: "zsh" | "bash"): Promise<void> {
+  const configPath = getConfigPath(shell)
+  if (!configPath || !existsSync(configPath)) {
+    return
+  }
+
+  const content = await readFile(configPath, "utf-8")
+  if (!content.includes(WRAPPER_SIGNATURE)) {
+    return
+  }
+
+  const lines = content.split("\n")
+  const startIndex = lines.findIndex((line) => line.includes(WRAPPER_SIGNATURE))
+
+  if (startIndex !== -1) {
+    const endIndex = findSetupEndIndex(lines, startIndex)
+
+    // Remove the integration block including surrounding blank lines
+    const removeStart =
+      startIndex > 0 && lines[startIndex - 1]?.trim() === "" ? startIndex - 1 : startIndex
+    const removeEnd =
+      endIndex + 1 < lines.length && lines[endIndex + 1]?.trim() === "" ? endIndex + 1 : endIndex
+
+    lines.splice(removeStart, removeEnd - removeStart + 1)
+    await writeFile(configPath, lines.join("\n"), "utf-8")
+  }
+}
+
+/**
+ * Detects the user's shell from environment
+ */
+export function detectShell(): "zsh" | "bash" | "unknown" {
+  const shell = process.env.SHELL?.toLowerCase() || ""
+
+  if (shell.includes("zsh")) {
+    return "zsh"
+  }
+  if (shell.includes("bash")) {
+    return "bash"
+  }
+
+  return "unknown"
+}
+
+/**
+ * Gets the config file path for the given shell
+ */
+export function getConfigPath(shell: "zsh" | "bash" | "unknown"): string | null {
+  const home = homedir()
+
+  switch (shell) {
+    case "zsh":
+      return join(home, ".zshrc")
+    case "bash":
+      return join(home, ".bashrc")
+    default:
+      return null
+  }
+}
+
+/**
+ * Finds the end index of the setup block, using end marker with fallback
+ */
+export function findSetupEndIndex(lines: string[], startIndex: number): number {
+  // Look for end marker first
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    if (lines[i]?.includes(SETUP_END_MARKER)) {
+      return i
+    }
+  }
+
+  // Fallback for old installations without end marker: find last closing brace
+  let endIndex = startIndex
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    if (lines[i]?.trim() === "}") {
+      endIndex = i
+    }
+    // Stop searching after a reasonable distance
+    if (i - startIndex > 50) break
+  }
+  return endIndex
+}
+
+/**
+ * Generates the full setup block including completions and wrapper function
+ */
+export function generateSetupBlock(shell: "zsh" | "bash", commandName: string): string {
+  const today = new Date().toISOString().split("T")[0]
+  const completions =
+    shell === "zsh" ? generateZshCompletions() : generateBashCompletions()
+
+  return `${WRAPPER_SIGNATURE} ${today}
 ${completions}
 ${commandName}() {
   if [ $# -eq 0 ]; then
@@ -218,11 +213,11 @@ ${commandName}() {
     command ${commandName} "$@"
   fi
 }
-${ShellIntegrationService.SETUP_END_MARKER}`
-  }
+${SETUP_END_MARKER}`
+}
 
-  private static generateBashCompletions(): string {
-    return `_branchlet_completions() {
+function generateBashCompletions(): string {
+  return `_branchlet_completions() {
   local cur="\${COMP_WORDS[COMP_CWORD]}"
   local commands="create list delete settings"
   local flags="--help --version --mode --from-wrapper"
@@ -233,10 +228,10 @@ ${ShellIntegrationService.SETUP_END_MARKER}`
   fi
 }
 complete -F _branchlet_completions branchlet`
-  }
+}
 
-  private static generateZshCompletions(): string {
-    return `_branchlet() {
+function generateZshCompletions(): string {
+  return `_branchlet() {
   local -a commands
   commands=(
     'create:Create a new worktree'
@@ -257,5 +252,4 @@ complete -F _branchlet_completions branchlet`
   esac
 }
 compdef _branchlet branchlet`
-  }
 }

--- a/src/services/update-service.ts
+++ b/src/services/update-service.ts
@@ -23,12 +23,13 @@ export class UpdateService {
 
   static async checkForUpdates(
     currentVersion: string,
-    configService: ConfigService
+    configService: ConfigService,
+    force = false
   ): Promise<UpdateCheckResult> {
     const config = configService.getConfig()
     const now = Date.now()
 
-    if (!UpdateService.shouldCheckForUpdates(configService)) {
+    if (!force && !UpdateService.shouldCheckForUpdates(configService)) {
       return (
         UpdateService.getCachedUpdateStatus(configService, currentVersion) || {
           hasUpdate: false,

--- a/src/services/update-service.ts
+++ b/src/services/update-service.ts
@@ -9,105 +9,102 @@ export interface UpdateCheckResult {
   error?: string
 }
 
-// biome-ignore lint/complexity/noStaticOnlyClass: Service class pattern
-export class UpdateService {
-  private static readonly NPM_REGISTRY_URL = "https://registry.npmjs.org/branchlet/latest"
-  private static readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/branchlet/latest"
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
-  static shouldCheckForUpdates(configService: ConfigService): boolean {
-    const config = configService.getConfig()
-    const lastCheck = config.lastUpdateCheck || 0
-    const now = Date.now()
-    return now - lastCheck >= UpdateService.CACHE_TTL_MS
-  }
+export function shouldCheckForUpdates(configService: ConfigService): boolean {
+  const config = configService.getConfig()
+  const lastCheck = config.lastUpdateCheck || 0
+  const now = Date.now()
+  return now - lastCheck >= CACHE_TTL_MS
+}
 
-  static async checkForUpdates(
-    currentVersion: string,
-    configService: ConfigService,
-    force = false
-  ): Promise<UpdateCheckResult> {
-    const config = configService.getConfig()
-    const now = Date.now()
+export async function checkForUpdates(
+  currentVersion: string,
+  configService: ConfigService,
+  force = false
+): Promise<UpdateCheckResult> {
+  const config = configService.getConfig()
+  const now = Date.now()
 
-    if (!force && !UpdateService.shouldCheckForUpdates(configService)) {
-      return (
-        UpdateService.getCachedUpdateStatus(configService, currentVersion) || {
-          hasUpdate: false,
-          currentVersion,
-          checkedAt: config.lastUpdateCheck || now,
-        }
-      )
-    }
-
-    try {
-      const latestVersion = await UpdateService.fetchLatestVersion()
-      const hasUpdate = isNewerVersion(currentVersion, latestVersion)
-
-      const updatedConfig = configService.updateConfig({
-        lastUpdateCheck: now,
-        latestVersion: latestVersion,
-        checkedVersion: currentVersion,
-      })
-
-      configService.saveConfig(updatedConfig).catch(() => {})
-
-      return {
-        hasUpdate,
-        currentVersion,
-        latestVersion,
-        checkedAt: now,
-      }
-    } catch (error) {
-      return {
+  if (!force && !shouldCheckForUpdates(configService)) {
+    return (
+      getCachedUpdateStatus(configService, currentVersion) || {
         hasUpdate: false,
         currentVersion,
-        checkedAt: now,
-        error: error instanceof Error ? error.message : String(error),
+        checkedAt: config.lastUpdateCheck || now,
       }
-    }
+    )
   }
 
-  static getCachedUpdateStatus(
-    configService: ConfigService,
-    currentVersion?: string
-  ): UpdateCheckResult | null {
-    const config = configService.getConfig()
+  try {
+    const latestVersion = await fetchLatestVersion()
+    const hasUpdate = isNewerVersion(currentVersion, latestVersion)
 
-    if (!config.lastUpdateCheck || !config.latestVersion) {
-      return null
-    }
+    const updatedConfig = configService.updateConfig({
+      lastUpdateCheck: now,
+      latestVersion: latestVersion,
+      checkedVersion: currentVersion,
+    })
 
-    const version = currentVersion || config.checkedVersion || config.latestVersion
-    const hasUpdate = isNewerVersion(version, config.latestVersion)
+    configService.saveConfig(updatedConfig).catch(() => {})
 
     return {
       hasUpdate,
-      currentVersion: version,
-      latestVersion: config.latestVersion,
-      checkedAt: config.lastUpdateCheck,
+      currentVersion,
+      latestVersion,
+      checkedAt: now,
+    }
+  } catch (error) {
+    return {
+      hasUpdate: false,
+      currentVersion,
+      checkedAt: now,
+      error: error instanceof Error ? error.message : String(error),
     }
   }
+}
 
-  private static async fetchLatestVersion(): Promise<string> {
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 5000)
+export function getCachedUpdateStatus(
+  configService: ConfigService,
+  currentVersion?: string
+): UpdateCheckResult | null {
+  const config = configService.getConfig()
 
-    try {
-      const response = await fetch(UpdateService.NPM_REGISTRY_URL, {
-        signal: controller.signal,
-        headers: {
-          Accept: "application/json",
-        },
-      })
+  if (!config.lastUpdateCheck || !config.latestVersion) {
+    return null
+  }
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`)
-      }
+  const version = currentVersion || config.checkedVersion || config.latestVersion
+  const hasUpdate = isNewerVersion(version, config.latestVersion)
 
-      const data = (await response.json()) as { version: string }
-      return data.version
-    } finally {
-      clearTimeout(timeoutId)
+  return {
+    hasUpdate,
+    currentVersion: version,
+    latestVersion: config.latestVersion,
+    checkedAt: config.lastUpdateCheck,
+  }
+}
+
+async function fetchLatestVersion(): Promise<string> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+  try {
+    const response = await fetch(NPM_REGISTRY_URL, {
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
     }
+
+    const data = (await response.json()) as { version: string }
+    return data.version
+  } finally {
+    clearTimeout(timeoutId)
   }
 }


### PR DESCRIPTION
## Summary
- "Check for Updates" in settings was returning cached results instead of actually checking npm. Now it bypasses the 24h TTL and fetches fresh.
- Adds `force` param to `UpdateService.checkForUpdates()` (defaults `false`, so startup behavior is unchanged)