### PR TITLE
Move update check state out of repo config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "glob": "^13.0.6",
         "ink": "^6.2.2",
         "ink-spinner": "^5.0.0",
-        "minimatch": "^10.2.2",
+        "minimatch": "^10.2.4",
         "minimist": "^1.2.8",
         "react": "^19.1.1",
         "zod": "^4.0.17",
@@ -24,6 +24,9 @@
         "typescript": "^5.9.2",
       },
     },
+  },
+  "overrides": {
+    "minimatch": "^10.2.3",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA=="],
@@ -130,7 +133,7 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
   },
   "overrides": {
-    "minimatch": "^10.2.3",
+    "minimatch": "^10.2.4",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-mkOh+Wwawzuf5wa30bvc4nA+Qb6DIrGWgBhRR/Pw4T9nsgYait8izvXkNyU78D6Wcu3Z+KUdwCmLCxlWjEotYA=="],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "glob": "^13.0.6",
     "ink": "^6.2.2",
     "ink-spinner": "^5.0.0",
-    "minimatch": "^10.2.2",
+    "minimatch": "^10.2.4",
     "minimist": "^1.2.8",
     "react": "^19.1.1",
     "zod": "^4.0.17"
@@ -61,6 +61,9 @@
     "bun-types": "^1.2.0",
     "react-devtools-core": "^4.28.5",
     "typescript": "^5.9.2"
+  },
+  "overrides": {
+    "minimatch": "^10.2.3"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
-    "minimatch": "^10.2.3"
+    "minimatch": "^10.2.4"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchlet",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CLI for creating and managing Git worktrees",
   "type": "module",
   "main": "dist/index.js",

--- a/schema.json
+++ b/schema.json
@@ -50,18 +50,6 @@
       "description": "Also delete the associated git branch when deleting a worktree",
       "default": false,
       "type": "boolean"
-    },
-    "lastUpdateCheck": {
-      "description": "Timestamp of last update check (milliseconds since epoch)",
-      "type": "number"
-    },
-    "latestVersion": {
-      "description": "Latest version available on npm",
-      "type": "string"
-    },
-    "checkedVersion": {
-      "description": "Version that was current when last checked",
-      "type": "string"
     }
   },
   "$id": "https://raw.githubusercontent.com/raghavpillai/branchlet/main/schema.json",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,6 +2,7 @@ import { Text, useInput } from "ink"
 import { useCallback, useEffect, useState } from "react"
 import packageJson from "../../package.json" with { type: "json" }
 import { COLORS } from "../constants/index.js"
+import { AppStateService } from "../services/app-state-service.js"
 import { ConfigService } from "../services/config-service.js"
 import { WorktreeService } from "../services/index.js"
 import type { ShellIntegrationStatus } from "../services/shell-integration-service.js"
@@ -63,18 +64,20 @@ export function App({ initialMode = "menu", isFromWrapper = false, onExit }: App
       const service = new WorktreeService(workingDir)
       await service.initialize()
 
-      const configService = service.getConfigService()
-      if (shouldCheckForUpdates(configService)) {
-        checkForUpdates(VERSION, configService)
+      const appStateService = new AppStateService()
+      await appStateService.load()
+
+      if (shouldCheckForUpdates(appStateService)) {
+        checkForUpdates(VERSION, appStateService)
           .then(setUpdateStatus)
           .catch(() => {
-            const cached = getCachedUpdateStatus(configService, VERSION)
+            const cached = getCachedUpdateStatus(appStateService, VERSION)
             if (cached) {
               setUpdateStatus(cached)
             }
           })
       } else {
-        const cached = getCachedUpdateStatus(configService, VERSION)
+        const cached = getCachedUpdateStatus(appStateService, VERSION)
         if (cached) {
           setUpdateStatus(cached)
         }

--- a/src/panels/settings/index.tsx
+++ b/src/panels/settings/index.tsx
@@ -98,7 +98,7 @@ export function SettingsMenu({ worktreeService, onBack }: SettingsMenuProps) {
           setCheckingUpdates(false)
         })
     }
-  }, [step, checkingUpdates, manualUpdateResult, worktreeService])
+  }, [step, checkingUpdates, manualUpdateResult])
 
   const resetConfig = async (): Promise<void> => {
     try {

--- a/src/panels/settings/index.tsx
+++ b/src/panels/settings/index.tsx
@@ -5,6 +5,7 @@ import { SelectPrompt, StatusIndicator } from "../../components/common/index.js"
 import { GLOBAL_CONFIG_FILE } from "../../constants/default-config.js"
 import { COLORS, MESSAGES } from "../../constants/index.js"
 import type { WorktreeConfig } from "../../schemas/config-schema.js"
+import { AppStateService } from "../../services/app-state-service.js"
 import type { WorktreeService } from "../../services/index.js"
 import type { UpdateCheckResult } from "../../services/update-service.js"
 import { checkForUpdates } from "../../services/update-service.js"
@@ -79,9 +80,10 @@ export function SettingsMenu({ worktreeService, onBack }: SettingsMenuProps) {
   useEffect(() => {
     if (step === "check-updates" && !checkingUpdates && !manualUpdateResult) {
       setCheckingUpdates(true)
-      const configService = worktreeService.getConfigService()
-
-      checkForUpdates(VERSION, configService, true)
+      const appStateService = new AppStateService()
+      appStateService
+        .load()
+        .then(() => checkForUpdates(VERSION, appStateService, true))
         .then((result) => {
           setManualUpdateResult(result)
           setCheckingUpdates(false)

--- a/src/schemas/app-state-schema.ts
+++ b/src/schemas/app-state-schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const AppStateSchema = z.object({
+  lastUpdateCheck: z
+    .number()
+    .optional()
+    .describe("Timestamp of last update check (milliseconds since epoch)"),
+  latestVersion: z.string().optional().describe("Latest version available on npm"),
+  checkedVersion: z.string().optional().describe("Version that was current when last checked"),
+})
+
+export type AppState = z.infer<typeof AppStateSchema>
+
+export const DEFAULT_APP_STATE: AppState = AppStateSchema.parse({})

--- a/src/schemas/config-schema.ts
+++ b/src/schemas/config-schema.ts
@@ -30,12 +30,6 @@ export const WorktreeConfigSchema = z
       .boolean()
       .default(false)
       .describe("Also delete the associated git branch when deleting a worktree"),
-    lastUpdateCheck: z
-      .number()
-      .optional()
-      .describe("Timestamp of last update check (milliseconds since epoch)"),
-    latestVersion: z.string().optional().describe("Latest version available on npm"),
-    checkedVersion: z.string().optional().describe("Version that was current when last checked"),
   })
   .describe("Configuration for Git worktree management tool")
 

--- a/src/services/app-state-service.ts
+++ b/src/services/app-state-service.ts
@@ -1,0 +1,46 @@
+import { access, mkdir, readFile, writeFile } from "node:fs/promises"
+import { GLOBAL_CONFIG_DIR } from "../constants/index"
+import { AppStateSchema, DEFAULT_APP_STATE, type AppState } from "../schemas/app-state-schema.js"
+
+const STATE_FILE = `${GLOBAL_CONFIG_DIR}/state.json`
+
+export class AppStateService {
+  private state: AppState
+
+  constructor() {
+    this.state = { ...DEFAULT_APP_STATE }
+  }
+
+  async load(): Promise<AppState> {
+    try {
+      await access(STATE_FILE)
+      const content = await readFile(STATE_FILE, "utf-8")
+      const parsed = JSON.parse(content)
+      const result = AppStateSchema.safeParse(parsed)
+      if (result.success) {
+        this.state = result.data
+      }
+    } catch {
+      // No state file yet, use defaults
+    }
+    return this.state
+  }
+
+  async save(): Promise<void> {
+    try {
+      await mkdir(GLOBAL_CONFIG_DIR, { recursive: true })
+      await writeFile(STATE_FILE, JSON.stringify(this.state, null, 2), "utf-8")
+    } catch {
+      // Non-critical, silently ignore
+    }
+  }
+
+  getState(): AppState {
+    return { ...this.state }
+  }
+
+  update(updates: Partial<AppState>): AppState {
+    this.state = { ...this.state, ...updates }
+    return this.getState()
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
+export * from "./app-state-service.js"
 export * from "./config-service.js"
 export * from "./file-service.js"
 export * from "./git-service.js"

--- a/src/services/update-service.ts
+++ b/src/services/update-service.ts
@@ -1,4 +1,4 @@
-import type { ConfigService } from "./config-service.js"
+import type { AppStateService } from "./app-state-service.js"
 import { isNewerVersion } from "../utils/version-compare.js"
 
 export interface UpdateCheckResult {
@@ -12,27 +12,27 @@ export interface UpdateCheckResult {
 const NPM_REGISTRY_URL = "https://registry.npmjs.org/branchlet/latest"
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
-export function shouldCheckForUpdates(configService: ConfigService): boolean {
-  const config = configService.getConfig()
-  const lastCheck = config.lastUpdateCheck || 0
+export function shouldCheckForUpdates(appStateService: AppStateService): boolean {
+  const state = appStateService.getState()
+  const lastCheck = state.lastUpdateCheck || 0
   const now = Date.now()
   return now - lastCheck >= CACHE_TTL_MS
 }
 
 export async function checkForUpdates(
   currentVersion: string,
-  configService: ConfigService,
+  appStateService: AppStateService,
   force = false
 ): Promise<UpdateCheckResult> {
-  const config = configService.getConfig()
+  const state = appStateService.getState()
   const now = Date.now()
 
-  if (!force && !shouldCheckForUpdates(configService)) {
+  if (!force && !shouldCheckForUpdates(appStateService)) {
     return (
-      getCachedUpdateStatus(configService, currentVersion) || {
+      getCachedUpdateStatus(appStateService, currentVersion) || {
         hasUpdate: false,
         currentVersion,
-        checkedAt: config.lastUpdateCheck || now,
+        checkedAt: state.lastUpdateCheck || now,
       }
     )
   }
@@ -41,13 +41,13 @@ export async function checkForUpdates(
     const latestVersion = await fetchLatestVersion()
     const hasUpdate = isNewerVersion(currentVersion, latestVersion)
 
-    const updatedConfig = configService.updateConfig({
+    appStateService.update({
       lastUpdateCheck: now,
       latestVersion: latestVersion,
       checkedVersion: currentVersion,
     })
 
-    configService.saveConfig(updatedConfig).catch(() => {})
+    appStateService.save().catch(() => {})
 
     return {
       hasUpdate,
@@ -66,23 +66,23 @@ export async function checkForUpdates(
 }
 
 export function getCachedUpdateStatus(
-  configService: ConfigService,
+  appStateService: AppStateService,
   currentVersion?: string
 ): UpdateCheckResult | null {
-  const config = configService.getConfig()
+  const state = appStateService.getState()
 
-  if (!config.lastUpdateCheck || !config.latestVersion) {
+  if (!state.lastUpdateCheck || !state.latestVersion) {
     return null
   }
 
-  const version = currentVersion || config.checkedVersion || config.latestVersion
-  const hasUpdate = isNewerVersion(version, config.latestVersion)
+  const version = currentVersion || state.checkedVersion || state.latestVersion
+  const hasUpdate = isNewerVersion(version, state.latestVersion)
 
   return {
     hasUpdate,
     currentVersion: version,
-    latestVersion: config.latestVersion,
-    checkedAt: config.lastUpdateCheck,
+    latestVersion: state.latestVersion,
+    checkedAt: state.lastUpdateCheck,
   }
 }
 

--- a/tests/schemas/json-schema.test.ts
+++ b/tests/schemas/json-schema.test.ts
@@ -62,9 +62,6 @@ describe("JSON Schema", () => {
         "postCreateCmd",
         "terminalCommand",
         "deleteBranchWithWorktree",
-        "lastUpdateCheck",
-        "latestVersion",
-        "checkedVersion",
       ]
 
       for (const field of expectedFields) {
@@ -84,11 +81,6 @@ describe("JSON Schema", () => {
       // String fields
       expect(properties.worktreePathTemplate.type).toBe("string")
       expect(properties.terminalCommand.type).toBe("string")
-      expect(properties.latestVersion.type).toBe("string")
-      expect(properties.checkedVersion.type).toBe("string")
-
-      // Number fields
-      expect(properties.lastUpdateCheck.type).toBe("number")
 
       // Boolean fields
       expect(properties.deleteBranchWithWorktree.type).toBe("boolean")


### PR DESCRIPTION
Closes #32

## Summary
- `lastUpdateCheck`, `latestVersion`, `checkedVersion` no longer live in `.branchlet.json` -- transient state, not user config
- New `AppStateService` reads/writes `~/.branchlet/state.json` for update check state
- Update service and UI components use the state service instead of config
- Regenerated `schema.json` without the update fields