### PR TITLE
Fix non-origin remote branches hidden from source branch picker

### DIFF
--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -167,10 +167,11 @@ export class GitService {
       // Deduplicate: skip origin/* branches that have a local counterpart,
       // but always include branches from other remotes (e.g. upstream/main)
       // since they represent distinct refs the user may want to branch from.
-      const isOrigin = remote.name.startsWith("origin/")
-      const shortName = remote.name.replace(/^[^/]+\//, "")
-      if (isOrigin && localNames.has(shortName)) {
-        continue
+      if (remote.name.startsWith("origin/")) {
+        const shortName = remote.name.replace(/^origin\//, "")
+        if (localNames.has(shortName)) {
+          continue
+        }
       }
       branches.push(remote)
     }

--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -164,11 +164,15 @@ export class GitService {
     const remoteBranches = await this.listRemoteBranches()
     const localNames = new Set(branches.map((b) => b.name))
     for (const remote of remoteBranches) {
-      // Deduplicate: skip remote branches that have a local counterpart
+      // Deduplicate: skip origin/* branches that have a local counterpart,
+      // but always include branches from other remotes (e.g. upstream/main)
+      // since they represent distinct refs the user may want to branch from.
+      const isOrigin = remote.name.startsWith("origin/")
       const shortName = remote.name.replace(/^[^/]+\//, "")
-      if (!localNames.has(shortName)) {
-        branches.push(remote)
+      if (isOrigin && localNames.has(shortName)) {
+        continue
       }
+      branches.push(remote)
     }
 
     return branches

--- a/tests/services/git-service.test.ts
+++ b/tests/services/git-service.test.ts
@@ -154,14 +154,17 @@ describe("GitService", () => {
     test("should always include non-origin remote branches regardless of local counterparts", async () => {
       try {
         const allBranches = await gitService.listBranches()
-        const nonOriginRemotes = allBranches.filter(
-          (b) => b.isRemote && !b.name.startsWith("origin/")
+        const allRemotes = await gitService.listRemoteBranches()
+        const nonOriginRemotes = allRemotes.filter(
+          (b) => !b.name.startsWith("origin/")
         )
 
         // Every non-origin remote branch (e.g. upstream/main) must appear
-        // even when a local branch with the same short name exists.
-        for (const branch of nonOriginRemotes) {
-          expect(allBranches).toContain(branch)
+        // in listBranches() — even when a local branch with the same short
+        // name exists.
+        const allBranchNames = new Set(allBranches.map((b) => b.name))
+        for (const remote of nonOriginRemotes) {
+          expect(allBranchNames.has(remote.name)).toBe(true)
         }
       } catch (error) {
         expect(error).toBeInstanceOf(Error)

--- a/tests/services/git-service.test.ts
+++ b/tests/services/git-service.test.ts
@@ -133,7 +133,7 @@ describe("GitService", () => {
       }
     })
 
-    test("should not duplicate local branches when including remotes", async () => {
+    test("should not duplicate origin branches when a local counterpart exists", async () => {
       try {
         const allBranches = await gitService.listBranches()
         const localNames = new Set(
@@ -141,10 +141,27 @@ describe("GitService", () => {
         )
 
         for (const branch of allBranches) {
-          if (branch.isRemote) {
-            const shortName = branch.name.replace(/^[^/]+\//, "")
+          if (branch.isRemote && branch.name.startsWith("origin/")) {
+            const shortName = branch.name.replace(/^origin\//, "")
             expect(localNames.has(shortName)).toBe(false)
           }
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+      }
+    })
+
+    test("should always include non-origin remote branches regardless of local counterparts", async () => {
+      try {
+        const allBranches = await gitService.listBranches()
+        const nonOriginRemotes = allBranches.filter(
+          (b) => b.isRemote && !b.name.startsWith("origin/")
+        )
+
+        // Every non-origin remote branch (e.g. upstream/main) must appear
+        // even when a local branch with the same short name exists.
+        for (const branch of nonOriginRemotes) {
+          expect(allBranches).toContain(branch)
         }
       } catch (error) {
         expect(error).toBeInstanceOf(Error)


### PR DESCRIPTION
# Description ✍️

The deduplication logic in `listBranches()` used a generic short-name comparison (stripping everything before the first `/`) to suppress remote branches that matched a local branch. This silently dropped branches from **non-origin remotes** (e.g. `upstream/main`) whenever a local branch with the same short name existed — a common situation in fork-based workflows where users have both a local `main` and an `upstream/main`.

The fix scopes deduplication to `origin/*` branches only. Branches from other remotes (`upstream`, mirrors, etc.) are always included so they appear in the source branch picker.

**Modules affected:** `src/services/git-service.ts`, `tests/services/git-service.test.ts`


# Overview 🔍

### Before

```
origin/main  →  deduplicated (local main exists) ✅
upstream/main  →  deduplicated (local main exists) ❌ wrongly hidden
```

### After

```
origin/main  →  deduplicated (local main exists) ✅
upstream/main  →  always included ✅
```

**Root cause** — `src/services/git-service.ts` (before fix):

```ts
// Deduplicate: skip remote branches that have a local counterpart
const shortName = remote.name.replace(/^[^/]+\//, "")
if (!localNames.has(shortName)) {
  branches.push(remote)
}
```

The regex `/^[^/]+\//` strips any remote prefix, so `upstream/main` and `origin/main` both resolve to `main` and are both suppressed when a local `main` exists.

**Fix** — deduplication now only applies to `origin/*`:

```ts
if (remote.name.startsWith("origin/")) {
  const shortName = remote.name.replace(/^origin\//, "")
  if (localNames.has(shortName)) {
    continue
  }
}
branches.push(remote)
```


# Test Guidance 🦮

**Preconditions:**
- A repository with at least two remotes configured (e.g. `origin` and `upstream`).
- A local branch (e.g. `main`) that shares a short name with a branch on the non-origin remote (e.g. `upstream/main`).

**Steps:**

1. Open the branch picker / source branch selector in the UI.
2. Observe the list of available branches.
3. **Expected:** `upstream/main` (or equivalent non-origin remote branch) is visible in the list alongside the local `main`.
4. **Expected:** `origin/main` is **not** duplicated — only one entry for the local `main` appears (deduplication still works for origin).
5. Create a new branch using `upstream/main` as the source.
6. **Expected:** the branch is created from the correct upstream ref without errors.

**Edge cases:**
- Repository with no non-origin remotes → behaviour unchanged; all origin deduplication still works.
- Remote branch whose short name has no local counterpart → still appears in the list regardless of remote name.
- Multiple non-origin remotes (e.g. `upstream` and `mirror`) → all their branches appear.

**Regression checks:**
- Verify that `origin/feature-branch` is still suppressed when a local `feature-branch` exists.
- Run the test suite: `npm test` — the updated and new tests in `tests/services/git-service.test.ts` cover both the deduplication contract and the new non-origin inclusion guarantee.
