### PR TITLE
Add -b flag to CLI and pre-populate branch name in TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,45 @@ branchlet --version  # Show version number
 branchlet -m create  # Set initial mode
 ```
 
+### Non-Interactive (Scriptable) CLI
+
+Pass flags to skip the interactive prompts entirely. The three core concepts map directly to flags:
+
+| Flag | Description |
+|------|-------------|
+| `-n, --name <name>` | Worktree directory name |
+| `-s, --source <branch>` | Source branch to create from |
+| `-b, --branch <branch>` | New branch name (defaults to `-n` when omitted) |
+
+```bash
+# Create a worktree — new branch defaults to the worktree name
+branchlet create -n my-feature -s main
+
+# Create a worktree with an explicit branch name different from the directory
+branchlet create -n ticket-3121-backend -s main -b feature/ticket-3121
+
+# Create multiple sibling worktrees from the same source branch
+# (each gets its own branch, so there's no checkout conflict)
+branchlet create -n digit3121-backend  -s main -b feat/digit3121-backend
+branchlet create -n digit3121-frontend -s main -b feat/digit3121-frontend
+
+# List worktrees as JSON
+branchlet list --json
+
+# Delete a worktree by name
+branchlet delete -n my-feature
+
+# Force-delete a worktree by path
+branchlet delete -p /path/to/worktree -f
+```
+
+Successful `create` output:
+```
+/path/to/worktree
+  source: main
+  branch: my-feature
+```
+
 ## Configuration
 
 Branchlet looks for configuration files in this order:

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -20,6 +20,10 @@ export async function runCreate(args: CliArgs, worktreeService: WorktreeService)
     throw new Error(`Invalid directory name: ${dirError}`)
   }
 
+  if (args.branch !== undefined && !args.branch.trim()) {
+    throw new Error("Branch name cannot be empty")
+  }
+
   if (args.branch) {
     const branchError = validateBranchName(args.branch)
     if (branchError) {
@@ -36,9 +40,10 @@ export async function runCreate(args: CliArgs, worktreeService: WorktreeService)
     throw new Error(`Source branch '${args.source}' does not exist`)
   }
 
-  // For remote branches without an explicit --branch, derive a local name
-  const newBranch =
-    args.branch ?? (sourceBranchEntry.isRemote ? args.source.replace(/^[^/]+\//, "") : args.source)
+  // When --branch is omitted, default to the worktree directory name so a fresh
+  // branch is always created (avoids conflicts when the source branch is already
+  // checked out in another worktree).
+  const newBranch = args.branch ?? args.name
 
   const worktreePath = getWorktreePath(
     gitService.getGitRoot(),
@@ -57,4 +62,6 @@ export async function runCreate(args: CliArgs, worktreeService: WorktreeService)
   })
 
   console.log(worktreePath)
+  console.log(`  source: ${args.source}`)
+  console.log(`  branch: ${newBranch}`)
 }

--- a/src/panels/create/index.tsx
+++ b/src/panels/create/index.tsx
@@ -302,6 +302,7 @@ export function CreateWorktree({ worktreeService, onComplete, onCancel }: Create
         <InputPrompt
           label={MESSAGES.CREATE_NEW_BRANCH_PROMPT}
           placeholder={MESSAGES.CREATE_NEW_BRANCH_PLACEHOLDER}
+          defaultValue={state.directoryName}
           validate={validateNewBranchName}
           onSubmit={handleNewBranchSubmit}
           onCancel={onCancel}

--- a/tests/cli/commands/create.test.ts
+++ b/tests/cli/commands/create.test.ts
@@ -143,6 +143,15 @@ describe("CLI create command", () => {
       }
     })
 
+    test("should throw for empty branch name", async () => {
+      const service = new WorktreeService()
+      await service.initialize()
+
+      await expect(
+        runCreate({ command: "create", name: "test-wt", source: sourceBranch, branch: "" }, service)
+      ).rejects.toThrow("cannot be empty")
+    })
+
     test("should throw for nonexistent source branch", async () => {
       const service = new WorktreeService()
       await service.initialize()
@@ -164,47 +173,12 @@ describe("CLI create command", () => {
   })
 
   describe("branch defaults", () => {
-    test("should default newBranch to source when --branch is omitted", async () => {
+    test("should default newBranch to the worktree directory name when --branch is omitted", async () => {
       const service = new WorktreeService()
       await service.initialize()
 
-      // This will attempt to create a worktree using the source branch directly.
-      // It may fail if the branch is already checked out, but the error should NOT
-      // be about missing arguments or validation.
-      const args: CliArgs = {
-        command: "create",
-        name: "test-default-branch",
-        source: sourceBranch,
-      }
+      const wtName = `test-default-branch-${Date.now()}`
 
-      try {
-        await runCreate(args, service)
-        createdWorktrees.push("test-default-branch")
-      } catch (error) {
-        // Expected: "already checked out" since main is the current branch
-        expect(error).toBeInstanceOf(Error)
-        expect((error as Error).message).not.toContain("Missing required argument")
-        expect((error as Error).message).not.toContain("Invalid")
-      }
-    })
-  })
-
-  describe("successful creation", () => {
-    test("should create worktree and output path to stdout", async () => {
-      const service = new WorktreeService()
-      await service.initialize()
-
-      const branchName = `feat/cli-test-create-${Date.now()}`
-      const wtName = `cli-test-create-${Date.now()}`
-
-      const args: CliArgs = {
-        command: "create",
-        name: wtName,
-        source: sourceBranch,
-        branch: branchName,
-      }
-
-      // Capture console.log output
       const logs: string[] = []
       const originalLog = console.log
       console.log = (...msgArgs: unknown[]) => {
@@ -212,12 +186,98 @@ describe("CLI create command", () => {
       }
 
       try {
-        await runCreate(args, service)
+        await runCreate({ command: "create", name: wtName, source: sourceBranch }, service)
         createdWorktrees.push(wtName)
 
-        // Should have logged the worktree path
-        expect(logs.length).toBeGreaterThan(0)
+        // The branch line in the output should name the worktree, not the source branch
+        const branchLine = logs.find((l) => l.trimStart().startsWith("branch:"))
+        expect(branchLine).toBeDefined()
+        expect(branchLine).toContain(wtName)
+      } finally {
+        console.log = originalLog
+      }
+    })
+  })
+
+  describe("successful creation", () => {
+    test("should create worktree and output path, source, and branch to stdout", async () => {
+      const service = new WorktreeService()
+      await service.initialize()
+
+      const branchName = `feat/cli-test-create-${Date.now()}`
+      const wtName = `cli-test-create-${Date.now()}`
+
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...msgArgs: unknown[]) => {
+        logs.push(msgArgs.map(String).join(" "))
+      }
+
+      try {
+        await runCreate({ command: "create", name: wtName, source: sourceBranch, branch: branchName }, service)
+        createdWorktrees.push(wtName)
+
         expect(logs[0]).toContain(wtName)
+        const sourceLine = logs.find((l) => l.trimStart().startsWith("source:"))
+        const branchLine = logs.find((l) => l.trimStart().startsWith("branch:"))
+        expect(sourceLine).toContain(sourceBranch)
+        expect(branchLine).toContain(branchName)
+      } finally {
+        console.log = originalLog
+      }
+    })
+
+    test("should allow explicit -b that differs from -n", async () => {
+      const service = new WorktreeService()
+      await service.initialize()
+
+      const wtName = `cli-test-diffname-${Date.now()}`
+      const branchName = `feature/different-name-${Date.now()}`
+
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...msgArgs: unknown[]) => {
+        logs.push(msgArgs.map(String).join(" "))
+      }
+
+      try {
+        await runCreate({ command: "create", name: wtName, source: sourceBranch, branch: branchName }, service)
+        createdWorktrees.push(wtName)
+
+        const branchLine = logs.find((l) => l.trimStart().startsWith("branch:"))
+        expect(branchLine).toContain(branchName)
+        expect(branchLine).not.toContain(wtName)
+      } finally {
+        console.log = originalLog
+      }
+    })
+
+    test("should create two sibling worktrees from the same source branch", async () => {
+      const service1 = new WorktreeService()
+      await service1.initialize()
+      const service2 = new WorktreeService()
+      await service2.initialize()
+
+      const ts = Date.now()
+      const wt1 = `cli-sibling-a-${ts}`
+      const wt2 = `cli-sibling-b-${ts}`
+      const branch1 = `feat/sibling-a-${ts}`
+      const branch2 = `feat/sibling-b-${ts}`
+
+      const originalLog = console.log
+      console.log = () => {}
+
+      try {
+        await runCreate({ command: "create", name: wt1, source: sourceBranch, branch: branch1 }, service1)
+        createdWorktrees.push(wt1)
+
+        await runCreate({ command: "create", name: wt2, source: sourceBranch, branch: branch2 }, service2)
+        createdWorktrees.push(wt2)
+
+        const worktrees = await service1.getGitService().listWorktrees()
+        const paths = worktrees.map((wt) => wt.path)
+        expect(paths.some((p) => p.endsWith(wt1))).toBe(true)
+        expect(paths.some((p) => p.endsWith(wt2))).toBe(true)
       } finally {
         console.log = originalLog
       }


### PR DESCRIPTION
# Description ✍️

Two related improvements that align the interactive TUI and the non-interactive CLI around the same three-concept model: **worktree directory name**, **source branch**, and **new branch name**.

**Interactive TUI** — the "new branch" input field is now pre-populated with the worktree directory name the user entered in the previous step. Previously the field was blank, forcing the user to retype a name they had already provided. The value is fully editable; clearing it and submitting blank still falls back to checking out the source branch directly (existing behaviour).

**Non-interactive CLI** — when `-b` is omitted from `branchlet create`, the new branch now defaults to the worktree directory name (`-n`) instead of the source branch. The old default caused a Git conflict error whenever the source branch (e.g. `main`) was already checked out in another worktree. The new default always creates a fresh branch, matching what the interactive flow now does. Additional changes:
- Empty `-b ""` is explicitly rejected with a clear error message.
- Success output now prints the worktree path, source branch, and created branch name.

README updated with a new **Non-Interactive (Scriptable) CLI** section that documents `-n`, `-s`, and `-b` as distinct concepts with a reference table and examples.


# Overview 🔍

### Interactive TUI — branch name pre-populated

Before:
```
Enter name for new branch (leave blank to use source branch):
┌──────────────────┐
│ |                │   ← blank, user must type from scratch
└──────────────────┘
```

After:
```
Enter name for new branch (leave blank to use source branch):
┌──────────────────────┐
│ my-feature|          │   ← pre-filled with the directory name
└──────────────────────┘
```

---

### Non-interactive CLI — default branch and richer output

Before (would fail if `main` is already checked out):
```bash
$ branchlet create -n my-feature -s main
# Error: 'main' is already checked out
```

After (always creates a fresh branch):
```bash
$ branchlet create -n my-feature -s main
/path/to/repo.worktree/my-feature
  source: main
  branch: my-feature

$ branchlet create -n ticket-3121-backend -s main -b feature/ticket-3121
/path/to/repo.worktree/ticket-3121-backend
  source: main
  branch: feature/ticket-3121
```

Multiple sibling worktrees from the same source — both succeed:
```bash
branchlet create -n digit3121-backend  -s main -b feat/digit3121-backend
branchlet create -n digit3121-frontend -s main -b feat/digit3121-frontend
```

---

### Files changed

| File | Change |
|------|--------|
| `src/panels/create/index.tsx` | Added `defaultValue={state.directoryName}` to the `new-branch` `InputPrompt` |
| `src/cli/commands/create.ts` | Default `newBranch` → `args.name`; empty `-b` validation; richer output |
| `tests/cli/commands/create.test.ts` | Updated defaults test + 4 new tests |
| `README.md` | New non-interactive CLI section with flag table and examples |


# Test Guidance 🦮

### Preconditions
- `branchlet` installed from this branch (`npm install -g .` from repo root)
- Any local Git repository with at least one branch (e.g. `main`) currently checked out

---

### Interactive TUI

1. Run `branchlet create` in a Git repository.
2. Enter a directory name, e.g. `my-feature`, and press Enter.
3. Select a source branch (e.g. `main`) and press Enter.
4. **Expected**: the "new branch" input is pre-populated with `my-feature`.
5. Press Enter to accept the default.
6. Confirm creation — worktree should be created with a new branch called `my-feature`.

**Edge case — clear and leave blank:**
7. Repeat steps 1–3, then delete the pre-populated value and press Enter with an empty field.
8. **Expected**: the worktree is created checking out the source branch directly (same as before this change).

**Edge case — edit the pre-populated value:**
9. Repeat steps 1–3, then edit the field to `feature/custom-name` and press Enter.
10. **Expected**: the worktree is created with branch `feature/custom-name`.

---

### Non-interactive CLI — default branch

```bash
branchlet create -n my-feature -s main
```
**Expected**: a new branch `my-feature` is created from `main`; output includes `branch: my-feature`. No conflict even when `main` is currently checked out.

---

### Non-interactive CLI — explicit `-b`

```bash
branchlet create -n ticket-backend -s main -b feature/ticket-123
```
**Expected**: worktree directory is `ticket-backend`, checked-out branch is `feature/ticket-123`; output includes `branch: feature/ticket-123`.

---

### Non-interactive CLI — sibling worktrees from the same source

```bash
branchlet create -n sibling-a -s main -b feat/sibling-a
branchlet create -n sibling-b -s main -b feat/sibling-b
```
**Expected**: both commands succeed; `branchlet list` shows two new worktrees each on their own branch.

---

### Non-interactive CLI — validation errors

```bash
branchlet create -n my-feature -s main -b ""
```
**Expected**: exits with error `Branch name cannot be empty`.

```bash
branchlet create -n my-feature -s main -b "invalid branch name"
```
**Expected**: exits with error `Invalid branch name`.

```bash
branchlet create -n my-feature -s nonexistent-branch
```
**Expected**: exits with error `Source branch 'nonexistent-branch' does not exist`.

---

### Regression checks

- `branchlet list` and `branchlet delete` should be unaffected.
- Existing worktrees should continue to appear in `branchlet list`.
- Interactive create flow steps other than "new branch" (directory name, source branch selection, confirm) should behave as before.
