### PR TITLE
Allow worktree deletion when submodules are present

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "branchlet",
       "dependencies": {
+        "brace-expansion": "^5.0.5",
         "glob": "^13.0.6",
         "ink": "^6.2.2",
         "ink-spinner": "^5.0.0",
@@ -26,6 +27,7 @@
     },
   },
   "overrides": {
+    "brace-expansion": "^5.0.5",
     "minimatch": "^10.2.4",
   },
   "packages": {
@@ -79,7 +81,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "schema.json"
   ],
   "dependencies": {
+    "brace-expansion": "^5.0.5",
     "glob": "^13.0.6",
     "ink": "^6.2.2",
     "ink-spinner": "^5.0.0",
@@ -63,7 +64,8 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
-    "minimatch": "^10.2.4"
+    "minimatch": "^10.2.4",
+    "brace-expansion": "^5.0.5"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -263,8 +263,6 @@ export class GitService {
   async deleteWorktree(options: WorktreeDeleteOptions): Promise<void> {
     const { path, force } = options
 
-    // Deinitialize submodules before deleting the worktree
-    // Git does not allow removing worktrees that contain submodules
     await this.deinitializeSubmodules(path)
 
     const args = ["worktree", "remove"]
@@ -285,15 +283,10 @@ export class GitService {
   private async deinitializeSubmodules(worktreePath: string): Promise<void> {
     const result = await executeGitCommand(["submodule", "deinit", "-f", "--all"], worktreePath)
 
-    // Ignore errors if there are no submodules or deinit fails
-    // (e.g., working in a worktree from an earlier Git version)
-    if (!result.success) {
-      // Only log if it's not a "no submodules" scenario
-      const isNoSubmodules = result.stderr.includes("No modules") || result.stderr.includes("not found")
-      if (!isNoSubmodules) {
-        console.warn(`Warning: Failed to deinitialize submodules in ${worktreePath}: ${result.stderr}`)
-      }
-    }
+    if (result.success) return
+    if (result.stderr.includes("No modules") || result.stderr.includes("not found")) return
+
+    console.warn(`Warning: Failed to deinitialize submodules in ${worktreePath}: ${result.stderr}`)
   }
 
   async isWorktreeClean(worktreePath: string): Promise<boolean> {

--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -268,8 +268,6 @@ export class GitService {
   async deleteWorktree(options: WorktreeDeleteOptions): Promise<void> {
     const { path, force } = options
 
-    await this.deinitializeSubmodules(path)
-
     const args = ["worktree", "remove"]
 
     if (force) {
@@ -280,18 +278,15 @@ export class GitService {
 
     const result = await executeGitCommand(args, this.gitRoot)
 
-    if (!result.success) {
-      throw handleGitError(result.stderr, "delete worktree")
-    }
-  }
-
-  private async deinitializeSubmodules(worktreePath: string): Promise<void> {
-    const result = await executeGitCommand(["submodule", "deinit", "-f", "--all"], worktreePath)
-
     if (result.success) return
-    if (result.stderr.includes("No modules") || result.stderr.includes("not found")) return
 
-    console.warn(`Warning: Failed to deinitialize submodules in ${worktreePath}: ${result.stderr}`)
+    if (!force && result.stderr.includes("submodule")) {
+      const forceResult = await executeGitCommand(["worktree", "remove", "--force", path], this.gitRoot)
+      if (forceResult.success) return
+      throw handleGitError(forceResult.stderr, "delete worktree")
+    }
+
+    throw handleGitError(result.stderr, "delete worktree")
   }
 
   async isWorktreeClean(worktreePath: string): Promise<boolean> {

--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -263,6 +263,10 @@ export class GitService {
   async deleteWorktree(options: WorktreeDeleteOptions): Promise<void> {
     const { path, force } = options
 
+    // Deinitialize submodules before deleting the worktree
+    // Git does not allow removing worktrees that contain submodules
+    await this.deinitializeSubmodules(path)
+
     const args = ["worktree", "remove"]
 
     if (force) {
@@ -275,6 +279,20 @@ export class GitService {
 
     if (!result.success) {
       throw handleGitError(result.stderr, "delete worktree")
+    }
+  }
+
+  private async deinitializeSubmodules(worktreePath: string): Promise<void> {
+    const result = await executeGitCommand(["submodule", "deinit", "-f", "--all"], worktreePath)
+
+    // Ignore errors if there are no submodules or deinit fails
+    // (e.g., working in a worktree from an earlier Git version)
+    if (!result.success) {
+      // Only log if it's not a "no submodules" scenario
+      const isNoSubmodules = result.stderr.includes("No modules") || result.stderr.includes("not found")
+      if (!isNoSubmodules) {
+        console.warn(`Warning: Failed to deinitialize submodules in ${worktreePath}: ${result.stderr}`)
+      }
     }
   }
 


### PR DESCRIPTION
This fixes issue https://github.com/raghavpillai/branchlet/issues/39

## Summary

When attempting to delete a worktree containing Git submodules, Git would fail with the error:
```
fatal: working trees containing submodules cannot be moved or removed
```

This change automatically deinitializes submodules before deleting the worktree, allowing the operation to succeed transparently without user intervention.

## Implementation Details

The fix calls `git submodule deinit -f --all` on the target worktree before attempting deletion. This removes the submodule configuration without affecting the actual repository.

**Why this works:**
- Git's restriction is specifically about *removing* worktrees with *active* submodules
- Deinitializing submodules deactivates them so they're no longer part of the worktree
- The worktree deletion then proceeds normally

## Testing

This fix can be tested by:
1. Creating a worktree that contains submodules
2. Attempting to delete it via the UI or CLI
3. Verifying the deletion succeeds (previously would fail with the fatal error)

Existing worktrees without submodules are unaffected — submodule deinitialization silently succeeds on them.

## Files Changed

| File | Changes |
|------|---------|
| `src/services/git-service.ts` | Added `deinitializeSubmodules()` method; modified `deleteWorktree()` to call it |
