### PR TITLE
Fix CI security audit and main worktree detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
     },
   },
   "overrides": {
+    "brace-expansion": "^5.0.5",
     "minimatch": "^10.2.4",
   },
   "packages": {
@@ -79,7 +80,7 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branchlet",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CLI for creating and managing Git worktrees",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
-    "minimatch": "^10.2.4"
+    "minimatch": "^10.2.4",
+    "brace-expansion": "^5.0.5"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -92,14 +92,9 @@ export class GitService {
       worktrees.push(currentWorktree as GitWorktree)
     }
 
-    if (worktrees.length > 0) {
-      const firstWorktree = worktrees[0]
-      if (firstWorktree) {
-        const gitRoot = this.gitRoot
-        if (firstWorktree.path === gitRoot || firstWorktree.path === gitRoot.replace(/\/$/, "")) {
-          firstWorktree.isMain = true
-        }
-      }
+    // The first entry from `git worktree list` is always the main worktree
+    if (worktrees.length > 0 && worktrees[0]) {
+      worktrees[0].isMain = true
     }
 
     for (const worktree of worktrees) {


### PR DESCRIPTION
## Summary

**tldr: Fix the CI security audit failure and a broken test for main worktree detection.**

`brace-expansion` had a moderate vulnerability (GHSA-f886-m6hf-6m8v) that was failing `bun audit` in CI. The `should include the main worktree` test was also broken -- `listWorktrees()` compared file paths to find the main worktree, but that comparison fails when you run from inside a worktree since cwd doesn't match the repo root.

## Changes

- Add `brace-expansion: ^5.0.5` override in package.json to resolve the security advisory
- Simplify main worktree detection in `listWorktrees()` to just mark the first entry -- git always lists the main worktree first