### PR TITLE
Enter in the created worktree after creating one

### DIFF
--- a/src/components/app-router.tsx
+++ b/src/components/app-router.tsx
@@ -46,6 +46,11 @@ export function AppRouter({
 }: AppRouterProps) {
   const [borderColor, setBorderColor] = useState<string>(COLORS.MUTED)
 
+  const handlePathSelect = (path: string): void => {
+    process.stdout.write(`${path}\n`)
+    onExit()
+  }
+
   return (
     <BorderContext.Provider value={{ setBorderColor }}>
       <Box flexDirection="column">
@@ -69,6 +74,8 @@ export function AppRouter({
               worktreeService={worktreeService}
               onComplete={onBackToMenu}
               onCancel={onBackToMenu}
+              isFromWrapper={isFromWrapper}
+              onPathSelect={handlePathSelect}
             />
           </Box>
         )}
@@ -79,10 +86,7 @@ export function AppRouter({
               worktreeService={worktreeService}
               onBack={onBackToMenu}
               isFromWrapper={isFromWrapper}
-              onPathSelect={(path) => {
-                process.stdout.write(`${path}\n`)
-                onExit()
-              }}
+              onPathSelect={handlePathSelect}
             />
           </Box>
         )}

--- a/src/panels/create/index.tsx
+++ b/src/panels/create/index.tsx
@@ -22,9 +22,17 @@ interface CreateWorktreeProps {
   worktreeService: WorktreeService
   onComplete: () => void
   onCancel: () => void
+  isFromWrapper?: boolean
+  onPathSelect?: (path: string) => void
 }
 
-export function CreateWorktree({ worktreeService, onComplete, onCancel }: CreateWorktreeProps) {
+export function CreateWorktree({
+  worktreeService,
+  onComplete,
+  onCancel,
+  isFromWrapper = false,
+  onPathSelect,
+}: CreateWorktreeProps) {
   const [state, setState] = useState<CreateWorktreeState>({
     step: "directory",
     directoryName: "",
@@ -151,7 +159,9 @@ export function CreateWorktree({ worktreeService, onComplete, onCancel }: Create
       const worktreePath = getWorktreePath(
         gitRoot,
         state.directoryName,
-        config.worktreePathTemplate
+        config.worktreePathTemplate,
+        state.newBranch,
+        state.sourceBranch
       )
       const parentDir = worktreePath.replace(`/${state.directoryName}`, "")
 
@@ -199,6 +209,11 @@ export function CreateWorktree({ worktreeService, onComplete, onCancel }: Create
 
       if (config.terminalCommand) {
         await openTerminal(config.terminalCommand, worktreePath)
+      }
+
+      if (isFromWrapper && onPathSelect) {
+        onPathSelect(worktreePath)
+        return
       }
 
       setState((prev) => ({ ...prev, step: "success" }))


### PR DESCRIPTION
# Description ✍️

Fix issue → https://github.com/raghavpillai/branchlet/pull/47

Improve the worktree creation flow so wrapper-based TUI sessions immediately navigate into the newly created worktree instead of sending users back through the worktree list.


# Overview 🔍

- Reuse the existing wrapper path-selection behavior for the create flow.
- Automatically return the new worktree path after create-time setup completes.
- Fix create-time worktree path resolution so navigation matches templated worktree locations.

## Notes

- This only changes automatic directory switching for shell-wrapper usage.
- Non-wrapper TUI sessions keep the existing success-screen behavior.
- No visual UI redesign is included in this change.


# Test Guidance 🦮

1. Ensure shell integration is installed so `branchlet` runs through the wrapper.
2. From a repository that uses `branchlet`, run `branchlet`.
3. Choose `Create Worktree` and complete the prompts for a new worktree.
4. Confirm the worktree is created successfully.
5. Verify the TUI exits and your shell lands inside the new worktree directory automatically.
6. Run `pwd` and confirm it matches the created worktree path.
7. Repeat the flow in a repo/config that uses a custom `worktreePathTemplate` and verify the shell lands in the resolved templated location.
8. Repeat the flow with configured post-create commands and confirm navigation happens only after those commands finish.
9. Launch the TUI without wrapper-based directory switching support and verify creation still succeeds without attempting to change the parent shell directory.
